### PR TITLE
data layer iteration

### DIFF
--- a/src/components/MorphAttributes.tsx
+++ b/src/components/MorphAttributes.tsx
@@ -62,6 +62,9 @@ export default ({
   onSigilAttributeMouseEnter,
   onSigilAttributeMouseLeave,
 }: Props) => {
+  if (!attributes) {
+    return null;
+  }
   const { affinity, era, group, palette, quantumStatus, sigil, signature, variation } = attributes;
   const [isSigilFormPersisted, setIsSigilFormPersisted] = useState(false);
   const isEntangled = quantumStatus === 'Entangled';

--- a/src/graphql/search.gql
+++ b/src/graphql/search.gql
@@ -1,0 +1,50 @@
+query getNfts(
+  $orderBy: NFT_orderBy = tokenId
+  $orderDirection: OrderDirection = asc
+  $filter: NFT_filter
+) {
+  nfts(
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+    where: $filter
+    first: 100
+  ) {
+    id
+    tokenId
+  }
+}
+
+query getNftOwners(
+  $orderBy: NFTOwner_orderBy = lastActivityAtTimestamp
+  $orderDirection: OrderDirection = desc
+  $filter: NFTOwner_filter
+) {
+  nftowners(
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+    where: $filter
+    first: 100
+  ) {
+    id
+    nft { id tokenId }
+  }
+}
+
+query getTokenStorage(
+  $orderBy: TokenStorageValue_orderBy
+  $orderDirection: OrderDirection = asc
+  $filter: TokenStorageValue_filter
+) {
+  tokenStorageValues(
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+    where: $filter
+    first: 100
+  ) {
+    id
+    nft { id tokenId }
+    key
+    stringValue
+    intValue
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import App from './App';
@@ -6,6 +6,7 @@ import HomePage from './pages/HomePage';
 import MorphsByAddressPage from './pages/MorphsByAddressPage';
 import MorphDetailsPage from './pages/MorphDetailsPage';
 import './polyfills';
+import SearchTestPage from './pages/SearchTestPage';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -15,6 +16,11 @@ ReactDOM.render(
           <Route path="/" element={<HomePage />} />
           <Route path="/address/:addressOrName" element={<MorphsByAddressPage />} />
           <Route path="/token/:tokenId" element={<MorphDetailsPage />} />
+          <Route path="/search-test" element={
+            <Suspense fallback={null}>
+              <SearchTestPage />
+            </Suspense>
+          }/>
           <Route path="*" element={<Navigate replace to="/" />} />
         </Routes>
       </App>

--- a/src/lib/morphs.ts
+++ b/src/lib/morphs.ts
@@ -40,7 +40,8 @@ export interface MorphsMetadata {
   description: string
   /** will be rewritten as an HTTP uri */
   image: string
-  attributes: {
+  /** will be undefined if token is running a non-standard engine */
+  attributes?: {
     affinity: string
     era: string
     group: string
@@ -82,13 +83,11 @@ export const batchGetMorphDetails = async (
     const owner = data[idx * 2 + 0];
     const uri = data[idx * 2 + 1];
     const metadata = metadataFromTokenURI(uri);
-    return {
-      tokenId,
-      name: metadata.name,
-      description: metadata.description,
-      image: rewriteIpfsUri(metadata.image),
-      owner,
-      attributes: {
+
+    let attributes: MorphsMetadata['attributes'];
+
+    try {
+      attributes = {
         affinity: getAttribute(metadata, 'Affinity'),
         era: getAttribute(metadata, 'Era'),
         group: getAttribute(metadata, 'Group'),
@@ -97,7 +96,18 @@ export const batchGetMorphDetails = async (
         sigil: getAttribute(metadata, 'Sigil'),
         signature: getAttribute(metadata, 'Signature'),
         variation: getAttribute(metadata, 'Variation')
-      }
+      };
+    } catch (err) {
+      console.warn('unable to parse attributes -- token may be running a custom engine');
+    }
+
+    return {
+      tokenId,
+      name: metadata.name,
+      description: metadata.description,
+      image: rewriteIpfsUri(metadata.image),
+      owner,
+      attributes,
     }
   });
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,65 @@
+import { MORPHS_NFT_CONTRACT_ADDRESSES } from "../constants/contracts";
+import { RPC_URLS } from "../constants/rpc";
+import { getGraphClient } from "./graph";
+import { Nft_OrderBy, OrderDirection, TokenStorageValue_Filter, TokenStorageValue_OrderBy } from "./graph-generated";
+import { batchGetMorphDetails, MorphsMetadata } from "./morphs";
+
+export interface MorphsQuery {
+  sigils?: string[]
+  cursor?: string
+}
+
+export interface MorphsQueryResponse {
+  morphs: MorphsMetadata[]
+  nextCursor?: string
+}
+
+export const searchMorphs = async (query: MorphsQuery = {}, chainId = 1): Promise<MorphsQueryResponse> => {
+  const client = getGraphClient(chainId);
+  const collection = MORPHS_NFT_CONTRACT_ADDRESSES[chainId];
+  const rpcUrl = RPC_URLS[chainId];
+
+  let tokenStorageValueFilter: TokenStorageValue_Filter | undefined;
+
+  if (query.sigils) {
+    tokenStorageValueFilter = { collection, key: 'sigil', stringValue_in: query.sigils };
+  }
+
+  let tokenIds: string[] = [];
+  let nextCursor: string | undefined = undefined;
+
+  if (tokenStorageValueFilter) {
+    const resp = await client.getTokenStorage({
+      filter: tokenStorageValueFilter,
+      orderBy: TokenStorageValue_OrderBy.UpdatedAtTimestamp,
+      orderDirection: OrderDirection.Asc
+    });
+
+    if (resp.errors?.length) {
+      throw new Error('Graph request failed');
+    }
+
+    tokenIds = resp.data?.tokenStorageValues.map(tsv => tsv.nft.tokenId) ?? [];
+
+    // TODO: need to handle cursor if there is a sigil with > 100 NFTs
+  }
+
+  // default to searching entire collection
+  else {
+    const resp = await client.getNfts({
+      filter: query.cursor ? { tokenId_gt: query.cursor } : undefined,
+      orderBy: Nft_OrderBy.TokenId,
+      orderDirection: OrderDirection.Asc
+    });
+
+    tokenIds = resp.data?.nfts.map(nft => nft.tokenId) ?? [];
+
+    if (tokenIds.length > 0) {
+      nextCursor = tokenIds[tokenIds.length - 1];
+    }
+  }
+
+  const morphs = await batchGetMorphDetails(chainId, rpcUrl, tokenIds);
+
+  return { morphs, nextCursor };
+}

--- a/src/lib/sigils.ts
+++ b/src/lib/sigils.ts
@@ -1,0 +1,60 @@
+import { MORPHS_NFT_CONTRACT_ADDRESSES } from "../constants/contracts"
+import { getGraphClient } from "./graph"
+import { OrderDirection, StorageLocation, StorageType, TokenStorageValue_OrderBy } from "./graph-generated"
+import groupBy from 'lodash/groupBy';
+import sortBy from "lodash/sortBy";
+
+interface SigilStanding {
+  normalizedSigil: string
+  sigils: string[]
+  tokenIds: string[]
+  count: number
+}
+
+const normalizeSigil = (sigil: string): string => sigil.toUpperCase();
+
+/**
+ * get the sigil leaderboard
+ *
+ * TODO: this will not work if there are > 1000 sigils set
+ */
+export const getSigilLeaderboard = async (chainId = 1) => {
+  const client = getGraphClient(chainId);
+  const collectionAddress = MORPHS_NFT_CONTRACT_ADDRESSES[chainId];
+
+  const resp = await client.getTokenStorage({
+    filter: {
+      key:'sigil',
+      storageType: StorageType.String,
+      location: StorageLocation.Engine,
+      collection: collectionAddress.toLowerCase(),
+    },
+    orderBy: TokenStorageValue_OrderBy.UpdatedAtTimestamp,
+    orderDirection: OrderDirection.Desc
+  });
+
+  if (resp.errors?.length || !resp.data) {
+    throw new Error(`Graph request failed`);
+  }
+
+  const normalized = resp.data.tokenStorageValues.map(tsv => {
+    return {
+      tokenId: tsv.nft.tokenId,
+      sigil: tsv.stringValue ?? '',
+      normalizedSigil: normalizeSigil(tsv.stringValue ?? '')
+    }
+  });
+
+  const grouped = Object.entries(groupBy(normalized, x => x.normalizedSigil));
+
+  const aggregated = grouped.map<SigilStanding>(([normalizedSigil, group]) => {
+    const sigils = Array.from(new Set(group.map(g => g.sigil)));
+    const tokenIds = group.map(g => g.tokenId);
+    const count = group.length;
+    return { normalizedSigil, count, sigils, tokenIds };
+  });
+
+  const sorted = sortBy(aggregated, x => x.count).reverse();
+
+  return sorted;
+}

--- a/src/pages/MorphDetailsPage.tsx
+++ b/src/pages/MorphDetailsPage.tsx
@@ -125,17 +125,17 @@ const MorphDetails = ({ tokenId }: Props) => {
           <Description>
             <Markdown remarkPlugins={[remarkGfm]}>{description}</Markdown>
           </Description>
-          <Section>
-            <SectionHeading>Attributes</SectionHeading>
-            {data?.attributes && (
-              <MorphAttributes
-                attributes={data?.attributes}
-                isSigilFormVisible={isSigilFormVisible}
-                onSigilAttributeMouseEnter={() => setIsSigilFormVisible(true)}
-                onSigilAttributeMouseLeave={() => setIsSigilFormVisible(false)}
-              />
-            )}
-          </Section>
+          {data?.attributes && (
+            <Section>
+              <SectionHeading>Attributes</SectionHeading>
+                <MorphAttributes
+                  attributes={data?.attributes}
+                  isSigilFormVisible={isSigilFormVisible}
+                  onSigilAttributeMouseEnter={() => setIsSigilFormVisible(true)}
+                  onSigilAttributeMouseLeave={() => setIsSigilFormVisible(false)}
+                />
+            </Section>
+          )}
 
           {!isEnsLoading && (
             <Section>

--- a/src/pages/MorphsByAddressPage.tsx
+++ b/src/pages/MorphsByAddressPage.tsx
@@ -82,7 +82,7 @@ const MorphsByAddress = ({ addressOrName }: Props) => {
   const { data: morphs } = useMorphsByAddress(address);
 
   const affinities = useMemo(() => {
-    const counts = countBy(morphs, (x) => x.attributes.affinity);
+    const counts = countBy(morphs, (x) => x.attributes?.affinity);
 
     return Object.entries(counts)
       .map(([affinity, count]) => ({

--- a/src/pages/SearchTestPage.tsx
+++ b/src/pages/SearchTestPage.tsx
@@ -1,0 +1,37 @@
+import { useRef, useState } from "react";
+import { useQuery } from "react-query"
+import { Link } from "react-router-dom";
+import useChainId from "../hooks/useChainId";
+import { searchMorphs } from "../lib/search";
+
+export default () => {
+  const chainId = useChainId();
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const nextCursor = useRef<string | undefined>(undefined);
+
+  const query = useQuery(['search', chainId, cursor], async () => {
+    // w/o any filter arguments, search the entire catalog
+    // const resp = await searchMorphs({ cursor });
+    const resp = await searchMorphs({ sigils: ['Reaper', 'REAPER'], cursor });
+    console.log(resp);
+    return resp;
+  });
+
+  nextCursor.current = query.data?.nextCursor;
+
+  if (!query.data) {
+    return null;
+  }
+
+  return <div>
+    <button onClick={() => setCursor(nextCursor.current)}>next</button>
+    <div>
+      {query.data.morphs.map(morph => <div>
+        <Link to={`/token/${morph.tokenId}`}>
+          {morph.tokenId} - {morph.name}
+        </Link>
+      </div>)}
+    </div>
+  </div>
+
+}


### PR DESCRIPTION
- new `searchMorphs` method to search entire catalog with cursor-based pagination
- only supports `sigils` array for now, more to come
- new `getSigilLeaderboard` method that returns aggregated/normalized/sorted standings

```typescript
interface SigilStanding {
  normalizedSigil: string
  sigils: string[]
  tokenIds: string[]
  count: number
}
```